### PR TITLE
Instruct Django that it should attach queryset exceptions to the ORM …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     pass
 
-VERSION = '0.4.7'
+VERSION = '0.4.8'
 
 if __name__ == '__main__':
     setup(
@@ -35,7 +35,7 @@ if __name__ == '__main__':
         ),
         zip_safe = False,
         install_requires = (
-            'Django>=1.10.5,<2.1',
+            'Django>=1.10.5,<2.2',
             'django-tastypie>=0.13.3',
             'mongoengine>=0.13.0',
             'python-dateutil>=2.5.0',

--- a/tastypie_mongoengine/resources.py
+++ b/tastypie_mongoengine/resources.py
@@ -569,19 +569,19 @@ class MongoEngineResource(resources.ModelResource, metaclass=MongoEngineModelDec
         try:
             return super(MongoEngineResource, self).obj_get(bundle=bundle, **kwargs)
         except self._meta.object_class.DoesNotExist as ex:
-            exp = models_base.subclass_exception('DoesNotExist', (self._meta.object_class.DoesNotExist, exceptions.ObjectDoesNotExist), self._meta.object_class.DoesNotExist.__module__)
+            exp = models_base.subclass_exception('DoesNotExist', (self._meta.object_class.DoesNotExist, exceptions.ObjectDoesNotExist), self._meta.object_class.DoesNotExist.__module__, type(self))
             raise exp(*ex.args)
         except queryset.DoesNotExist as ex:
-            exp = models_base.subclass_exception('DoesNotExist', (queryset.DoesNotExist, exceptions.ObjectDoesNotExist), queryset.DoesNotExist.__module__)
+            exp = models_base.subclass_exception('DoesNotExist', (queryset.DoesNotExist, exceptions.ObjectDoesNotExist), queryset.DoesNotExist.__module__, type(self))
             raise exp(*ex.args)
         except self._meta.object_class.MultipleObjectsReturned as ex:
-            exp = models_base.subclass_exception('MultipleObjectsReturned', (self._meta.object_class.MultipleObjectsReturned, exceptions.MultipleObjectsReturned), self._meta.object_class.MultipleObjectsReturned.__module__)
+            exp = models_base.subclass_exception('MultipleObjectsReturned', (self._meta.object_class.MultipleObjectsReturned, exceptions.MultipleObjectsReturned), self._meta.object_class.MultipleObjectsReturned.__module__, type(self))
             raise exp(*ex.args)
         except queryset.MultipleObjectsReturned as ex:
-            exp = models_base.subclass_exception('MultipleObjectsReturned', (queryset.MultipleObjectsReturned, exceptions.MultipleObjectsReturned), queryset.MultipleObjectsReturned.__module__)
+            exp = models_base.subclass_exception('MultipleObjectsReturned', (queryset.MultipleObjectsReturned, exceptions.MultipleObjectsReturned), queryset.MultipleObjectsReturned.__module__, type(self))
             raise exp(*ex.args)
         except mongoengine.ValidationError as ex:
-            exp = models_base.subclass_exception('DoesNotExist', (queryset.DoesNotExist, exceptions.ObjectDoesNotExist), queryset.DoesNotExist.__module__)
+            exp = models_base.subclass_exception('DoesNotExist', (queryset.DoesNotExist, exceptions.ObjectDoesNotExist), queryset.DoesNotExist.__module__, type(self))
             raise exp(*ex.args)
 
     def obj_create(self, bundle, **kwargs):


### PR DESCRIPTION
…model, in the Django 2.1 required attached_to argument

In Django 2.1, the `attached_to` argument was made required when creating ORM model exceptions e.g. `model.DoesNotExist`. This change appears to have been made to ensure that this exception could be reliably pickled.

I've attempted to recreate the usage of this function from elsewhere in the Django source code by passing in the `type()` reference to the ORM model, which has the `__qualname__` property available. You can find a similar implementation here in the Django source: https://github.com/django/django/blob/216eda103bee71725b26421e578705f24e17dae0/django/db/models/base.py#L108

If I'm understanding this regression correctly, it is not imperative that my fix be 100% correct. `django-tastypie-mongoengine` has effectively never supported pickling of these exceptions, so the specific `__qualname__` provided should not be terribly consequential. The most important fix here is that we now provide Django with all of the required arguments to `subclass_exception`. That said, I've done my best to pick the best class reference to provide to `attached_to`.